### PR TITLE
Use call-service rather than toggle for claiming chore

### DIFF
--- a/files/kc_dashboard_da.yaml
+++ b/files/kc_dashboard_da.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/kc_dashboard_de.yaml
+++ b/files/kc_dashboard_de.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/kc_dashboard_en.yaml
+++ b/files/kc_dashboard_en.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/kc_dashboard_fi.yaml
+++ b/files/kc_dashboard_fi.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/kc_dashboard_fr.yaml
+++ b/files/kc_dashboard_fr.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/kc_dashboard_nl.yaml
+++ b/files/kc_dashboard_nl.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/kc_dashboard_sk.yaml
+++ b/files/kc_dashboard_sk.yaml
@@ -489,8 +489,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'

--- a/files/legacy_dashboards/kc-dashboard_KCD_0.2.7.yaml
+++ b/files/legacy_dashboards/kc-dashboard_KCD_0.2.7.yaml
@@ -324,8 +324,13 @@ sections:
                           'icon_color': icon_color,
                           'badge_icon': badge_icon,
                           'badge_color': badge_color,
-                          'tap_action': {
-                            'action': 'toggle'
+                         'tap_action': {
+                              'action': 'call-service',
+                              'service': 'kidschores.claim_chore',
+                              'data': {
+                                  'chore_name': primary,
+                                  'kid_name': ns.Kid_name
+                              }
                           },
                           'hold_action': {
                             'action': 'more-info'


### PR DESCRIPTION
I found that the chores were claimable on desktop, via click, but weren't working on my wall tablet (lenovo tab 11, using fully kiosk browser).

I noticed that most other `tap_action`s were using `call-service`, so tried that out for here, and it now works for both click and tap.